### PR TITLE
Feat: Do not re-infer the same audio multiple times

### DIFF
--- a/client/audio_engine.go
+++ b/client/audio_engine.go
@@ -31,17 +31,15 @@ type AudioEngine struct {
 	buf []byte
 
 	firstTimeStamp *uint32
-
-	we *WhisperEngine
+	we             *WhisperEngine
 }
 
-func NewAudioEngine() (*AudioEngine, error) {
+func NewAudioEngine(transcriptionStream chan TranscriptionSegment) (*AudioEngine, error) {
 	dec, err := opus.NewDecoder(sampleRate, channels)
 	if err != nil {
 		return nil, err
 	}
-
-	we, err := NewWhisperEngine()
+	we, err := NewWhisperEngine(transcriptionStream)
 	if err != nil {
 		return nil, err
 	}

--- a/client/audio_engine.go
+++ b/client/audio_engine.go
@@ -30,6 +30,8 @@ type AudioEngine struct {
 	// slice to hold binary encoded pcm data
 	buf []byte
 
+	firstTimeStamp *uint32
+
 	we *WhisperEngine
 }
 
@@ -82,26 +84,42 @@ func (a *AudioEngine) decode() {
 			return
 		}
 		// log.Printf("got pkt of size %d", len(pkt.Payload))
+		if pkt.SequenceNumber == 0 {
+			log.Print("Resetting timestamp bc sequencenumber 0...")
+			a.firstTimeStamp = &pkt.Timestamp
+		}
+		if a.firstTimeStamp == nil {
+			log.Print("Resetting timestamp bc firstTimeStamp is nil...  ", pkt.Timestamp)
+			a.firstTimeStamp = &pkt.Timestamp
+		}
+
 		if _, err := a.decodePacket(pkt); err != nil {
 			log.Fatalf("error decoding opus packet %+v", err)
 		} else {
+
 			// log.Printf("decoded %d bytes", n)
 			// if _, err = f.Write(a.buf[:n]); err != nil {
 			// 	log.Fatalf("error writing to file %+v", err)
 			// }
 		}
-
 	}
 }
 
 func (a *AudioEngine) decodePacket(pkt *rtp.Packet) (int, error) {
+	_, err := a.dec.DecodeFloat32(pkt.Payload, a.pcm)
 	// we decode to float32 here since that is what whisper.cpp takes
-	if _, err := a.dec.DecodeFloat32(pkt.Payload, a.pcm); err != nil {
+	if err != nil {
 		log.Printf("error decoding fb packet %+v", err)
 		return 0, err
 	} else {
 		// log.Printf("decoded %d FB samples", n)
-		a.we.Write(a.pcm)
+		// log.Printf("decoded %d samples", len(a.pcm))
+		// log.Printf("timestamps %d %d", pkt.Timestamp, *a.firstTimeStamp)
+		// log.Printf("Calc %d", (pkt.Timestamp-(*a.firstTimeStamp))/(sampleRate*3))
+		timestampMS := (pkt.Timestamp - (*a.firstTimeStamp)) / ((sampleRate / 1000) * 3)
+		lengthOfRecording := uint32(len(a.pcm)) * 3
+		timestampRecordingEnds := timestampMS + lengthOfRecording
+		a.we.Write(a.pcm, timestampRecordingEnds)
 		return convertToBytes(a.pcm, a.buf), nil
 	}
 }

--- a/client/saturday_client.go
+++ b/client/saturday_client.go
@@ -45,6 +45,14 @@ func NewSaturdayClient(config SaturdayConfig) *SaturdayClient {
 		return s.pc.AddIceCandidate(candidate)
 	})
 
+	// Starting a new goroutine to read from the channel
+	go func() {
+		for transcription := range transcriptionStream {
+			// Process the received transcription here
+			// For now, we will just log it
+			log.Printf("Received transcription: %s", transcription.text)
+		}
+	}()
 	return s
 }
 

--- a/client/saturday_client.go
+++ b/client/saturday_client.go
@@ -22,7 +22,8 @@ type SaturdayConfig struct {
 }
 
 func NewSaturdayClient(config SaturdayConfig) *SaturdayClient {
-	ae, err := NewAudioEngine()
+	transcriptionStream := make(chan TranscriptionSegment, 100)
+	ae, err := NewAudioEngine(transcriptionStream)
 	if err != nil {
 		log.Fatalf("failed to create audio engine %+v", err)
 	}

--- a/client/whisper.go
+++ b/client/whisper.go
@@ -17,13 +17,13 @@ type WhisperModel struct {
 
 type Transcription struct {
 	from           uint32
-	transcriptions []TrasncriptionSegment
+	transcriptions []TranscriptionSegment
 }
 
-type TrasncriptionSegment struct {
-	from uint32
-	to   uint32
-	text string
+type TranscriptionSegment struct {
+	startTimestamp uint32
+	endTimestamp   uint32
+	text           string
 }
 
 func NewWhisperModel() (*WhisperModel, error) {
@@ -56,16 +56,14 @@ func (w *WhisperModel) Process(samples []float32, recordingStartTime uint32) (er
 		return err, transcription
 	} else {
 		segments := w.ctx.Whisper_full_n_segments()
-		log.Printf("Got %d segments start %d", segments, recordingStartTime)
 		for i := 0; i < segments; i++ {
-			trasncriptionSegment := TrasncriptionSegment{}
+			trasncriptionSegment := TranscriptionSegment{}
 
-			trasncriptionSegment.from = uint32(w.ctx.Whisper_full_get_segment_t0(i) * 10)
-			trasncriptionSegment.to = uint32(w.ctx.Whisper_full_get_segment_t1(i) * 10)
+			trasncriptionSegment.startTimestamp = uint32(w.ctx.Whisper_full_get_segment_t0(i) * 10)
+			trasncriptionSegment.endTimestamp = uint32(w.ctx.Whisper_full_get_segment_t1(i) * 10)
 
 			trasncriptionSegment.text = w.ctx.Whisper_full_get_segment_text(i)
 
-			log.Printf("Segment %d %d- %d: %s", i, recordingStartTime+trasncriptionSegment.from, recordingStartTime+trasncriptionSegment.to, trasncriptionSegment.text)
 			transcription.transcriptions = append(transcription.transcriptions, trasncriptionSegment)
 		}
 	}

--- a/client/whisper_engine.go
+++ b/client/whisper_engine.go
@@ -61,7 +61,7 @@ func (we *WhisperEngine) Write(pcm []float32, Timestamp uint32) {
 	}
 	we.pcmWindow = append(we.pcmWindow, pcm...)
 	// We have filled up our window so lets run inference
-	if len(we.pcmWindow) == pcmWindowSize {
+	if len(we.pcmWindow) >= pcmWindowSize {
 		// TODO make this run in a go routine
 
 		err, transcription := we.runInference(Timestamp + whisperSampleWindowMs)
@@ -82,7 +82,7 @@ func (we *WhisperEngine) Write(pcm []float32, Timestamp uint32) {
 			log.Print("new endTimestamp: ", we.lastHandledTimestamp)
 
 		} else {
-			log.Printf("error running inference: ", err.Error())
+			log.Print("error running inference: ", err.Error())
 		}
 	}
 }


### PR DESCRIPTION
When the inference model generates multiple segments, and these segments are followed by subsequent ones, any segment with a follow-up is then published. The timestamp that marks the start for the next inference is set to the end of the last published segment. This approach ensures that the model doesn't needlessly re-infer the same audio content multiple times. It appears that this method yields high accuracy, especially when the model correctly identifies that a segment has been completed.

The transcribed segments are then forwarded to the SaturdayClient.

Thank you for your work :)